### PR TITLE
Fix seed provided test (accept 0)

### DIFF
--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -299,7 +299,7 @@ def run_simulation(
         result = simulation(
             config=config,
             num_consignments=num_consignments,
-            seed=seed + i if seed else None,
+            seed=seed + i if seed is not None else None,
             output_f280_file=output_f280_file,
             verbose=verbose,
             pretty=pretty,


### PR DESCRIPTION
The simulation-repeating function tested user-provided seed using just simple 'if seed'
which caused random seed to be generated automatically when seed 0 was provided.
Now seed is tested againts None which works as expec
