### PR TITLE
Test more seeds in basic simulation run

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,7 +72,7 @@ def run_pathways_cli(**kwargs):
 def test_gives_result(tmp_path):
     config = tmp_path / "config.yml"
     config.write_text(CONFIG)
-    for seed in range(10):
+    for seed in range(30):
         assert "slipped" in run_pathways_cli(
             num_consignments=10, config_file=str(config), seed=seed
         )


### PR DESCRIPTION
Not all seeds generate error which the code already accounted for.
However, 10 seeds was not enough to capture #123 which needed seed=15.
Test with seeds starting at 0, 100, 200, ..., 9000 showed that the #123 issue is hit
at first 10 seeds in 8 cases and in first 20 in two cases., so using 30 seeds
in the test to capture #123 plus 10 extra seeds, but still limit the number to minimum.
(Not using random seeds (which is what how #123 was actually discovered) because
that may result in random, hard to reproduce, errors in CI, so the usefulness is limited.)
