### PR TITLE
CI: Run jobs only on PR and main

### DIFF
--- a/.github/workflows/ci-long-running.yml
+++ b/.github/workflows/ci-long-running.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version:
+        - "3.9"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-long-running.yml
+++ b/.github/workflows/ci-long-running.yml
@@ -11,7 +11,6 @@ jobs:
 
     runs-on: ubuntu-20.04
     strategy:
-      max-parallel: 4
       matrix:
         python-version: [3.9]
 

--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -1,15 +1,18 @@
-name: Notebooks CI
+name: Example Notebooks
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
 
 jobs:
   run-notebooks:
 
     runs-on: ubuntu-20.04
     strategy:
-      max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version:
+        - "3.9"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -1,4 +1,4 @@
-name: Long running tests
+name: Example Scripts
 
 on:
   push:
@@ -7,13 +7,13 @@ on:
   pull_request:
 
 jobs:
-  notebooks:
+
+  test-scripts:
 
     runs-on: ubuntu-20.04
     strategy:
-      max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +25,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
-        pip install jupyter nbconvert matplotlib seaborn
-    - name: Run notebooks
+    - name: Run Bash example scripts
       run: |
-        jupyter nbconvert --execute --to notebook --inplace examples/notebooks/validation_plots.ipynb
+        cd examples/bash
+        ./bash_examples.sh
+        ./generate_synthetic_F280_dataset.sh test.csv 100
+    - name: Run Python example scripts
+      run: |
+        cd examples/python
+        ./scenarios.py

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version:
+        - "3.9"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,22 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
 
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.9
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -24,14 +24,14 @@ jobs:
 
   linting-flake8:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -43,14 +43,14 @@ jobs:
 
   linting-pylint:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -62,14 +62,14 @@ jobs:
 
   black-code-style:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -101,31 +101,3 @@ jobs:
     - name: Test with pytest
       run: |
         pytest tests/
-
-  test-scripts:
-
-    runs-on: ubuntu-20.04
-    strategy:
-      max-parallel: 2
-      matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install
-      run: |
-        python -m pip install --upgrade pip
-        pip install .
-    - name: Run Bash example scripts
-      run: |
-        cd examples/bash
-        ./bash_examples.sh
-        ./generate_synthetic_F280_dataset.sh test.csv 100
-    - name: Run Python example scripts
-      run: |
-        cd examples/python
-        ./scenarios.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,6 @@ on:
   pull_request:
 
 jobs:
-  build:
-
-    runs-on: ubuntu-20.04
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.9
-    - name: Install
-      run: |
-        python -m pip install --upgrade pip
-        pip install .
 
   linting-flake8:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: "3.9"
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: "3.9"
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -55,7 +55,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: "3.9"
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -71,7 +71,11 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version:
+        - "3.6"
+        - "3.7"
+        - "3.8"
+        - "3.9"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
* Does not run additional jobs for push event.
* Build is tested only for one Python version.
* Notebooks and scripts just for two latest versions.
* Test job still runs build and test for all supported Python versions.
* Overall there is less runs, but almost same coverage (not for example scripts and notebooks).
* Scripts test is now separate workflow similarly to notebooks.
* Python and Ubuntu versions updated.
