### PR TITLE
Add Cut Flower Release Program

### DIFF
--- a/docs/cfrp.md
+++ b/docs/cfrp.md
@@ -1,0 +1,98 @@
+# Cut Flower Release Program
+
+The _Cut Flower Release Program_ can be used to skip inspection of qualifying consignments.
+It is specified under `release_programs` using the key `cfrp`, for example:
+
+```yaml
+release_programs:
+  cfrp:
+```
+
+Consignments which qualify for the program may or may not be marked for inspection depending on
+an inspection schedule. Non-qualifying consignments are always marked for inspection.
+
+## Schedule
+
+The main component of the program is a schedule which
+specifies the _Flower of the Day_ (FotD). This is a flower (or generally, commodity)
+to inspect on a given day. At the same time, the schedule determines which flowers
+qualify for the program.
+
+The schedule is in tabular format. The following table shows three days of the schedule:
+
+| Date       | Commodity     | ORIGIN_NM   |
+| ---------- | ------------- | ----------- |
+| 2014-10-01 | Liatris       | Ecuador     |
+| 2014-10-02 | Sedum         | Netherlands |
+| 2014-10-03 | Bouquet, Rose | Colombia    |
+
+The same schedule in a CSV format:
+
+```csv
+"DATE","COMMODITY","ORIGIN_NM"
+"2014-10-01","Liatris","Ecuador"
+"2014-10-02","Sedum","Netherlands"
+"2014-10-03","Bouquet, Rose","Colombia"
+```
+
+The schedule file is specified in a YAML configuration file as follows:
+
+```yaml
+release_programs:
+  cfrp:
+    schedule:
+      file_name: schedule.csv
+```
+
+And in tabular configuration like this:
+
+| Parameter keys                           | Value        |
+| ---------------------------------------- | ------------ |
+| release_programs/cfrp/schedule/file_name | schedule.csv |
+
+Note that the column names in the schedule file must be `date`, `commodity`,
+and `origin_nm`. However, the case does not matter, so all of `date`, `Date`,
+and `DATE` are allowed.
+
+Format of the date can be specified using the `date_format` key under `schedule`.
+The value is a string with [format codes](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior)
+for Python's _strptime_ function, e.g., `%Y_%m_%d`. In YAML, use double quotes around
+the string, e.g., `"%Y_%m_%d"`, to specify it is a plain YAML string.
+
+The schedule can specify more than one FotD for a specific day, e.g., roses from
+Netherlands and roses from Mexico on November 3rd, 2014.
+Multiple identical entries in teh schedule are allowed and collapsed into one entry.
+
+## Participating Ports
+
+Ports participating in the program can be specified as a list under a key called `ports`.
+For example:
+
+```yaml
+release_programs:
+  cfrp:
+    schedule:
+      file_name: schedule.csv
+    ports:
+      - NY JFK CBP
+      - FL Miami Air CBP
+```
+
+Only when the consignment is in one of the ports in the list, it is considered for the program.
+If the consignment is in the port not in the list, it does not qualify for the program.
+
+## Output
+
+If the simulation is producing a F280-like text output, name of the program will appear
+in the output as `cfrp` when consignment qualified for the program. To customize this name,
+use, e.g., `name: CFRP` under the key `cfrp` like this:
+
+```yaml
+release_programs:
+  cfrp:
+    name: CFRP
+```
+
+---
+
+Next: [Inspections](inspections.md)

--- a/docs/inspections.md
+++ b/docs/inspections.md
@@ -1,5 +1,55 @@
 # Inspection configuration
 
+Each consignment is inspected according to the rules under the `inspection` configuration key.
+Optionally, inspection of some consignments can be skipped using a release programs.
+
+## Skipping inspections
+
+Inspections can be skipped using release programs specified under the key `release_programs`.
+
+Two programs are supported: a naive variation of the Cut Flower Release Program
+and a full version of the _Cut Flower Release Program_.
+
+Only one program can be specified at a time.
+
+### Naive Cut Flower Release Program
+
+A prototype implementation of a simple theoretical release program
+modeled after the Cut Flower Release Program (CFRP) is included in the
+simulation as _Naive Cut Flower Release Program_ (`naive_cfrp`). When
+activated, only one kind of flowers is inspected each day (a day is
+based on the date which is a attribute of the consignment). The program
+is applied to consignments which have flowers specified in `flowers` and
+which have less then `max_boxes`. The program parameters can be
+specified like this:
+
+```yaml
+release_programs:
+  naive_cfrp:
+    flowers:
+      - Hyacinthus
+      - Gerbera
+      - Rosa
+      - Actinidia
+    max_boxes: 10  # do not apply to consignments larger than
+```
+
+### Cut Flower Release Program
+
+_Main article: [Cut Flower Release Program](cfrp.md)_
+
+A full _Cut Flower Release Program_ (`cfrp`) is included in the simulation
+and is driven primarily by a schedule which determines qualifying flowers
+(or generally, commodities) and _Flower of the Day_ (FotD), a flower to inspect
+on a given day. A minimal configuration looks like this:
+
+```yaml
+release_programs:
+  cfrp:
+    schedule:
+      file_name: schedule.csv
+```
+
 ## Inspection unit
 
 The inspection unit can be determined by:
@@ -230,28 +280,6 @@ regardless of contaminant detection.
 The number of contaminated units detected for each end strategy is
 compared to quantify the proportion of contaminants reported when the
 inspection is ended at detection.
-
-## Naive Cut Flower Release Program
-
-A prototype implementation of a simple theoretical release program
-modeled after the Cut Flower Release Program (CFRP) is included in the
-simulation as _Naive Cut Flower Release Program_ (`naive_cfrp`). When
-activated, only one kind of flowers is inspected each day (a day is
-based on the date which is a attribute of the consignment). The program
-is applied to consignments which have flowers specified in `flowers` and
-which have less then `max_boxes`. The program parameters can be
-specified like this:
-
-```yaml
-release_programs:
-  naive_cfrp:
-    flowers:
-      - Hyacinthus
-      - Gerbera
-      - Rosa
-      - Actinidia
-    max_boxes: 10 # do not apply to consignments larger than
-```
 
 ---
 

--- a/popsborder/inspections.py
+++ b/popsborder/inspections.py
@@ -23,7 +23,6 @@
 
 from __future__ import print_function, division
 
-import functools
 import math
 import random
 import types
@@ -571,47 +570,6 @@ def get_sample_function(config):
     else:
         raise RuntimeError(f"Unknown sample strategy: {sample_strategy}")
     return sample
-
-
-def is_flower_of_the_day(cfrp, flower, date):
-    """Return True if the flower is FoTD based on naive criteria"""
-    i = date.day % len(cfrp)
-    if flower == cfrp[i]:
-        return True
-    return False
-
-
-def naive_cfrp(config, consignment, date):
-    """Decided if the consignment should be expected based on CFRP and size"""
-    # returns 2 bools: should_inspect, CFRP applied
-    flower = consignment.flower
-    cfrp = config["flowers"]
-    max_boxes = config["max_boxes"]
-    # we have flowers in the CFRP, flower is in CFRP, and not too big consignment
-    if cfrp and flower in cfrp and consignment.num_boxes <= max_boxes:
-        if is_flower_of_the_day(cfrp, flower, date):
-            return True, "naive_cfrp"  # is FotD, inspect
-        return False, "naive_cfrp"  # not FotD, release
-    return True, None  # not in CFRP or large, inspect
-
-
-def inspect_always(consignment, date):  # pylint: disable=unused-argument
-    """Inspect always"""
-    return True, None
-
-
-def get_inspection_needed_function(config):
-    """Based on config, return function to determine is inspection is needed."""
-    if "release_programs" in config:
-        for name in sorted(config["release_programs"].keys()):
-            # Notably, this does not support multiple programs at once.
-            # We simply return whatever is the first program alphabetically
-            # or raise exception if there is an unknown program name.
-            if name == "naive_cfrp":
-                return functools.partial(naive_cfrp, config["release_programs"][name])
-            else:
-                raise RuntimeError(f"Unknown release program: {name}")
-    return inspect_always
 
 
 def is_consignment_contaminated(consignment):

--- a/popsborder/simulation.py
+++ b/popsborder/simulation.py
@@ -29,11 +29,11 @@ import numpy as np
 from .consignments import get_consignment_generator, get_contaminant_function
 from .inspections import (
     consignment_contamination_rate,
-    get_inspection_needed_function,
     get_sample_function,
     inspect,
     is_consignment_contaminated,
 )
+from .skipping import get_inspection_needed_function
 from .outputs import (
     Form280,
     MuteReporter,

--- a/popsborder/skipping.py
+++ b/popsborder/skipping.py
@@ -22,6 +22,8 @@
 
 import functools
 
+from .inputs import load_cfrp_schedule
+
 
 def get_inspection_needed_function(config):
     """Based on config, return function to determine if inspection is needed.
@@ -85,20 +87,15 @@ class CutFlowerReleaseProgram:
     """
 
     def __init__(self, config, schedule=None):
-        self._config = config
-        self._program_name = self._config.get("name", "cfrp")
+        self._program_name = config.get("name", "cfrp")
         if schedule:
             self._schedule = schedule
         else:
-            self._schedule = self._load_schedule()
-
-    def _load_schedule(self):
-        """Load schedule from file based on configuration"""
-        # TODO: Maybe a year-month-day=>list of flowers dictionary is better.
-        # TODO: On the other hand, flowers=>dates dictionary could be used also
-        # as a list of eligible flowers.
-        # with open(self._config["schedule"])
-        return {}
+            schedule_config = config["schedule"]
+            self._schedule = load_cfrp_schedule(
+                schedule_config["file_name"],
+                date_format=schedule_config.get("date_format"),
+            )
 
     def __call__(self, consignment, date):
         """Decide if the consignment should be inspected based on CFRP"""

--- a/popsborder/skipping.py
+++ b/popsborder/skipping.py
@@ -96,11 +96,14 @@ class CutFlowerReleaseProgram:
                 schedule_config["file_name"],
                 date_format=schedule_config.get("date_format"),
             )
+        self._ports = config.get("ports")
 
     def __call__(self, consignment, date):
         """Decide if the consignment should be inspected based on CFRP"""
         # returns 2 bools: should_inspect, CFRP applied
         # we have flowers in the CFRP, flower is in CFRP
+        if self._ports and consignment.port not in self._ports:
+            return True, None  # inspect, not in CFRP
         dates_for_flower = self._schedule.get((consignment.flower, consignment.origin))
         if dates_for_flower:
             if date in dates_for_flower:

--- a/popsborder/skipping.py
+++ b/popsborder/skipping.py
@@ -1,0 +1,112 @@
+# Simulation of contaminated consignments and their inspections
+# Copyright (C) 2018-2022 Vaclav Petras and others (see below)
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see https://www.gnu.org/licenses/gpl-2.0.html
+
+
+"""Skipping inspections of consignments
+
+.. codeauthor:: Vaclav Petras <wenzeslaus gmail com>
+"""
+
+import functools
+
+
+def get_inspection_needed_function(config):
+    """Based on config, return function to determine if inspection is needed.
+
+    The returned function returns a tuple. The first item is a boolean telling if the
+    consignment should be inspected. The second item is a string which is the name of
+    the release program applied or None if no release program was applied.
+    """
+    if "release_programs" in config:
+        for name in sorted(config["release_programs"].keys()):
+            # Notably, this does not support multiple programs at once.
+            # We simply return whatever is the first program alphabetically
+            # or raise exception if there is an unknown program name.
+            if name == "cfrp":
+                return CutFlowerReleaseProgram(config["release_programs"][name])
+            elif name == "naive_cfrp":
+                return functools.partial(
+                    naive_cfrp, config["release_programs"][name], name
+                )
+            else:
+                raise RuntimeError(f"Unknown release program: {name}")
+    return inspect_always
+
+
+def inspect_always(consignment, date):  # pylint: disable=unused-argument
+    """Inspect always"""
+    return True, None
+
+
+def is_naive_flower_of_the_day(cfrp, flower, date):
+    """Return True if the flower is FoTD based on naive criteria"""
+    i = date.day % len(cfrp)
+    if flower == cfrp[i]:
+        return True
+    return False
+
+
+def naive_cfrp(config, name, consignment, date):
+    """Decide if the consignment should be inspected based on naive CFRP
+
+    Returns tuple with boolean and string. The boolean requests inspection and the
+    string is name of the program provided as parameter.
+    """
+    flower = consignment.flower
+    cfrp = config["flowers"]
+    max_boxes = config["max_boxes"]
+    # we have flowers in the CFRP, flower is in CFRP, and not too big consignment
+    if cfrp and flower in cfrp and consignment.num_boxes <= max_boxes:
+        if is_naive_flower_of_the_day(cfrp, flower, date):
+            return True, name  # is FotD, inspect
+        return False, name  # not FotD, release
+    return True, None  # not in CFRP or large, inspect
+
+
+class CutFlowerReleaseProgram:
+    """Cut Flower Release Program (CFRP)
+
+    Constructs CFRP, esp. the schedule, from the configuration during initialization.
+    Objects can be called as functions to evalute if consignments should be inspected
+    using this program.
+    """
+
+    def __init__(self, config, schedule=None):
+        self._config = config
+        self._program_name = self._config.get("name", "cfrp")
+        if schedule:
+            self._schedule = schedule
+        else:
+            self._schedule = self._load_schedule()
+
+    def _load_schedule(self):
+        """Load schedule from file based on configuration"""
+        # TODO: Maybe a year-month-day=>list of flowers dictionary is better.
+        # TODO: On the other hand, flowers=>dates dictionary could be used also
+        # as a list of eligible flowers.
+        # with open(self._config["schedule"])
+        return {}
+
+    def __call__(self, consignment, date):
+        """Decide if the consignment should be inspected based on CFRP"""
+        # returns 2 bools: should_inspect, CFRP applied
+        # we have flowers in the CFRP, flower is in CFRP
+        dates_for_flower = self._schedule.get((consignment.flower, consignment.origin))
+        if dates_for_flower:
+            if date in dates_for_flower:
+                return True, self._program_name  # is FotD, inspect
+            return False, self._program_name  # not FotD, release
+        return True, None  # not in CFRP, inspect

--- a/popsborder/skipping.py
+++ b/popsborder/skipping.py
@@ -99,14 +99,20 @@ class CutFlowerReleaseProgram:
         self._ports = config.get("ports")
 
     def __call__(self, consignment, date):
-        """Decide if the consignment should be inspected based on CFRP"""
-        # returns 2 bools: should_inspect, CFRP applied
-        # we have flowers in the CFRP, flower is in CFRP
+        """Decide if the consignment should be inspected based on CFRP
+
+        Returns a tuple which contains a boolean indicating whether or not the
+        consignment should be inspected and a string which is the name of the
+        program (default is 'cfrp') if it was applied. If the program was not
+        applied, None is returned.
+        """
+        # Check if we are in a participating port.
         if self._ports and consignment.port not in self._ports:
             return True, None  # inspect, not in CFRP
+        # Look up flower-origin combo is in the program.
         dates_for_flower = self._schedule.get((consignment.flower, consignment.origin))
         if dates_for_flower:
             if date in dates_for_flower:
-                return True, self._program_name  # is FotD, inspect
-            return False, self._program_name  # not FotD, release
-        return True, None  # not in CFRP, inspect
+                return True, self._program_name  # inspect, is FotD
+            return False, self._program_name  # release, in CFRP, but not FotD
+        return True, None  # inspect, not in CFRP

--- a/tests/test_cfrp.py
+++ b/tests/test_cfrp.py
@@ -1,0 +1,147 @@
+"""Test functions for skipping inspections directly"""
+
+import datetime
+
+from popsborder.consignments import Consignment, get_consignment_generator
+from popsborder.inputs import load_configuration_yaml_from_text
+from popsborder.simulation import random_seed
+from popsborder.skipping import (
+    CutFlowerReleaseProgram,
+    get_inspection_needed_function,
+    inspect_always,
+)
+
+BASE_CONSIGNMENT_CONFIG = """\
+consignment:
+  generation_method: parameter_based
+  items_per_box:
+    default: 200
+    air:
+      default: 200
+    maritime:
+      default: 200
+  parameter_based:
+    boxes:
+      min: 1
+      max: 100
+    origins:
+      - Netherlands
+      - Mexico
+      - Israel
+    flowers:
+      - Hyacinthus
+      - Rosa
+      - Gerbera
+    ports:
+      - NY JFK CBP
+      - FL Miami Air CBP
+      - HI Honolulu CBP
+"""
+
+CFRP_CONFIG = """\
+release_programs:
+  cfrp:
+    name: CFRP
+"""
+
+
+SCHEDULE = {
+    ("Liatris", "Dominican Republic"): [datetime.date(2017, 1, 1)],
+    ("Liatris", "Ecuador"): [datetime.date(2017, 1, 1)],
+    ("Rosa", "Colombia"): [datetime.date(2017, 1, 2)],
+    ("Lilium", "Colombia"): [datetime.date(2017, 1, 3)],
+    ("Lilium", "Costa Rica"): [datetime.date(2017, 1, 3)],
+}
+
+
+def simple_consignment(flower, origin, date):
+    """Get consignment with some default values"""
+    return Consignment(
+        flower=flower,
+        num_items=0,
+        items=0,
+        items_per_box=0,
+        num_boxes=0,
+        date=date,
+        boxes=[],
+        pathway="airport",
+        port="FL Miami Air CBP",
+        origin=origin,
+    )
+
+
+def test_cfrp():
+    """Check that CFRP program is accepted and gives expected results"""
+    consignment_generator = get_consignment_generator(
+        load_configuration_yaml_from_text(BASE_CONSIGNMENT_CONFIG)
+    )
+    is_needed_function = get_inspection_needed_function(
+        load_configuration_yaml_from_text(CFRP_CONFIG)
+    )
+    # The following assumes what is the default returned by the get function,
+    # i.e., it relies on its internals, not the interface.
+    # pylint: disable=comparison-with-callable
+    assert is_needed_function != inspect_always
+    for seed in range(10):
+        # We run with different, but fixed seeded so we can know which seed fails.
+        random_seed(seed)
+        consignment = consignment_generator.generate_consignment()
+        inspect, program = is_needed_function(consignment, consignment.date)
+        assert isinstance(inspect, bool)
+        # Testing custom name
+        assert program == "CFRP" or program is None
+
+
+def test_cfrp_inspect_in_program():
+    """Check inspection is requested for flower of the day"""
+    cfrp = CutFlowerReleaseProgram({}, schedule=SCHEDULE)
+    consignment = simple_consignment(
+        flower="Liatris", origin="Ecuador", date=datetime.date(2017, 1, 1)
+    )
+    inspect, program_name = cfrp(consignment, consignment.date)
+    assert inspect
+    assert program_name == "cfrp"
+
+
+def test_cfrp_not_inspect_in_program():
+    """Check inspection is not requested for flower-country combo on another day"""
+    cfrp = CutFlowerReleaseProgram({}, schedule=SCHEDULE)
+    consignment = simple_consignment(
+        flower="Liatris", origin="Ecuador", date=datetime.date(2017, 1, 2)
+    )
+    inspect, program_name = cfrp(consignment, consignment.date)
+    assert not inspect
+    assert program_name == "cfrp"
+
+
+def test_cfrp_inspect_flower_not_in_program():
+    """Check inspection is requested for flower which is not in the program"""
+    cfrp = CutFlowerReleaseProgram({}, schedule=SCHEDULE)
+    consignment = simple_consignment(
+        flower="Zantedeschia", origin="Ecuador", date=datetime.date(2017, 1, 1)
+    )
+    inspect, program_name = cfrp(consignment, consignment.date)
+    assert inspect
+    assert program_name is None
+
+
+def test_cfrp_inspect_country_not_in_program():
+    """Check inspection is requested for country which is not in the program"""
+    cfrp = CutFlowerReleaseProgram({}, schedule=SCHEDULE)
+    consignment = simple_consignment(
+        flower="Liatris", origin="Mexico", date=datetime.date(2017, 1, 1)
+    )
+    inspect, program_name = cfrp(consignment, consignment.date)
+    assert inspect
+    assert program_name is None
+
+
+def test_cfrp_inspect_flower_and_country_not_in_program():
+    """Check inspection is requested for out-of-program flower-country combo"""
+    cfrp = CutFlowerReleaseProgram({}, schedule=SCHEDULE)
+    consignment = simple_consignment(
+        flower="Zantedeschia", origin="Mexico", date=datetime.date(2017, 1, 1)
+    )
+    inspect, program_name = cfrp(consignment, consignment.date)
+    assert inspect
+    assert program_name is None

--- a/tests/test_skipping.py
+++ b/tests/test_skipping.py
@@ -1,10 +1,11 @@
-"""Test inspection functions directly"""
+"""Test functions for skipping inspections directly"""
 
 import pytest
-from popsborder.inputs import load_configuration_yaml_from_text
+
 from popsborder.consignments import get_consignment_generator
-from popsborder.inspections import get_inspection_needed_function, inspect_always
+from popsborder.inputs import load_configuration_yaml_from_text
 from popsborder.simulation import random_seed
+from popsborder.skipping import get_inspection_needed_function, inspect_always
 
 BASE_CONSIGNMENT_CONFIG = """\
 consignment:
@@ -63,6 +64,7 @@ def test_naive_cfrp():
     )
     # The following assumes what is the default returned by the get function,
     # i.e., it relies on its internals, not the interface.
+    # pylint: disable=comparison-with-callable
     assert is_needed_function != inspect_always
     for seed in range(10):
         # We run with different, but fixed seeded so we can know which seed fails.


### PR DESCRIPTION
This is a draft which includes basic structure for CFRP and moves all functionality to determine if the inspection is needed to a separate file.
The new module is called skipping as in skipping inspection, but it could be also release as in release programs (to keep it one word only). The config key is still called release_programs. One issue is that release happens even outside of release programs.
New tests are testing CFRP code directly.

What is missing is reading of CFRP schedule (for tests, it is provided directly in the code).
