### PR TITLE
Fix re-raising exceptions, simplify min, max, super

### DIFF
--- a/popsborder/app.py
+++ b/popsborder/app.py
@@ -43,7 +43,7 @@ class CustomHelpFormatter(argparse.RawTextHelpFormatter):
         """Add usage text"""
         if prefix is None:
             prefix = "Usage: "
-        return super(CustomHelpFormatter, self).add_usage(
+        return super().add_usage(
             usage, actions, groups, prefix
         )
 

--- a/popsborder/app.py
+++ b/popsborder/app.py
@@ -43,9 +43,7 @@ class CustomHelpFormatter(argparse.RawTextHelpFormatter):
         """Add usage text"""
         if prefix is None:
             prefix = "Usage: "
-        return super().add_usage(
-            usage, actions, groups, prefix
-        )
+        return super().add_usage(usage, actions, groups, prefix)
 
 
 def get_executable_name():

--- a/popsborder/consignments.py
+++ b/popsborder/consignments.py
@@ -204,7 +204,7 @@ class F280ConsignmentGenerator:
         except StopIteration:
             raise RuntimeError(
                 "More consignments requested than number of records in provided F280"
-            )
+            ) from None
 
         num_items = int(record["QUANTITY"])
         items = np.zeros(num_items, dtype=np.int64)
@@ -215,8 +215,7 @@ class F280ConsignmentGenerator:
 
         # rounding up to keep the max per box and have enough boxes
         num_boxes = int(math.ceil(num_items / float(items_per_box)))
-        if num_boxes < 1:
-            num_boxes = 1
+        num_boxes = max(num_boxes, 1)
         boxes = []
         for i in range(num_boxes):
             lower = i * items_per_box
@@ -255,7 +254,7 @@ class AQIMConsignmentGenerator:
         except StopIteration:
             raise RuntimeError(
                 "More consignments requested than number of records in AQIM data"
-            )
+            ) from None
         pathway = record["CARGO_FORM"]
         items_per_box = self.items_per_box
         items_per_box = get_items_per_box(items_per_box, pathway)
@@ -274,8 +273,7 @@ class AQIMConsignmentGenerator:
 
         # rounding up to keep the max per box and have enough boxes
         num_boxes = int(math.ceil(num_items / float(items_per_box)))
-        if num_boxes < 1:
-            num_boxes = 1
+        num_boxes = max(num_boxes, 1)
         boxes = []
         for i in range(num_boxes):
             lower = i * items_per_box

--- a/popsborder/inspections.py
+++ b/popsborder/inspections.py
@@ -264,8 +264,7 @@ def compute_n_clusters_to_inspect(config, consignment, n_items_to_inspect):
             inspect_per_box = math.ceil(n_items_to_inspect / max_boxes)
             # If not enough boxes to achieve sample size, inspect all items
             # and increase n_boxes_to_inspect as needed.
-            if inspect_per_box > items_per_box:
-                inspect_per_box = items_per_box
+            inspect_per_box = min(inspect_per_box, items_per_box)
             n_boxes_to_inspect = math.ceil(n_items_to_inspect / inspect_per_box)
     else:
         raise RuntimeError(f"Unknown cluster selection method: {cluster_selection}")


### PR DESCRIPTION
* Re-raising exceptions when we don't want the original exception visible needs to be done with raise ... from None.
* Use min and max to simplify code limiting range of a value.
* Simplify use of super() for Python 3.

This addresses Pylint warnings consider-using-max-builtin, consider-using-max-builtin, raise-missing-from, and super-with-arguments.
