### PR TITLE
Convert to pandas from one result with all columns

### DIFF
--- a/popsborder/outputs.py
+++ b/popsborder/outputs.py
@@ -526,6 +526,7 @@ def _flatten_nested_dict_generator(dictionary, parent_key):
 
 
 def flatten_nested_dict(dictionary, parent_key=None):
+    """Make a nested dictionary flat with key/subkey/subsubkey keys"""
     return dict(_flatten_nested_dict_generator(dictionary, parent_key))
 
 
@@ -560,8 +561,9 @@ def save_scenario_result_to_table(filename, results, config_columns, result_colu
 
 
 def save_simulation_result_to_pandas(
-    result, config, config_columns=None, result_columns=None
+    result, config=None, config_columns=None, result_columns=None
 ):
+    """Save result of one simulation to pandas DataFrame"""
     return save_scenario_result_to_pandas(
         [(result, config)], config_columns=config_columns, result_columns=result_columns
     )
@@ -583,14 +585,15 @@ def save_scenario_result_to_pandas(results, config_columns=None, result_columns=
     rows = []
     for result, config in results:
         row = {}
-        if config_columns:
-            for column in config_columns:
-                keys = column.split("/")
-                row[column] = get_item_from_nested_dict(config, keys)
-        elif config_columns is None:
-            row = flatten_nested_dict(config)
-        # When falsy, but not None, we assume it is an empty list and thus an
-        # explicit request for no config columns to be included.
+        if config:
+            if config_columns:
+                for column in config_columns:
+                    keys = column.split("/")
+                    row[column] = get_item_from_nested_dict(config, keys)
+            elif config_columns is None:
+                row = flatten_nested_dict(config)
+            # When falsy, but not None, we assume it is an empty list and thus an
+            # explicit request for no config columns to be included.
         if result_columns:
             for column in result_columns:
                 keys = column.split("/")

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -1,3 +1,5 @@
+"""Test functions which output to pandas"""
+
 import pytest
 
 from popsborder.inputs import load_configuration, load_scenario_table
@@ -12,21 +14,24 @@ NUM_ITEMS_IN_CONFIG = 33
 NUM_ATTRIBUTES_IN_RESULT = 25
 
 
-@pytest.fixture
-def config(datadir):
+@pytest.fixture(name="config")
+def fixture_config(datadir):
+    """Get loaded configuration"""
     return load_configuration(datadir / "config.yml")
 
 
-@pytest.fixture
-def executed_simulation_result(config):
+@pytest.fixture(name="result")
+def fixture_executed_simulation_result(config):
+    """Get result of a simulation after running it"""
     result = run_simulation(
         config=config, seed=42, num_simulations=2, num_consignments=10
     )
     return result
 
 
-def test_simulation_to_pandas_default_columns(executed_simulation_result, config):
-    df = save_simulation_result_to_pandas(executed_simulation_result, config)
+def test_simulation_to_pandas_default_columns(result, config):
+    """Check that one result with config coverts with default column values"""
+    df = save_simulation_result_to_pandas(result, config)
     print(df)
     shape = df.shape
     assert len(shape) == 2
@@ -35,10 +40,9 @@ def test_simulation_to_pandas_default_columns(executed_simulation_result, config
     assert rows == 1
 
 
-def test_simulation_to_pandas_no_config_columns(executed_simulation_result, config):
-    df = save_simulation_result_to_pandas(
-        executed_simulation_result, config, config_columns=[]
-    )
+def test_simulation_to_pandas_no_config(result):
+    """Check that one result without config coverts"""
+    df = save_simulation_result_to_pandas(result)
     shape = df.shape
     assert len(shape) == 2
     rows, cols = shape
@@ -46,7 +50,18 @@ def test_simulation_to_pandas_no_config_columns(executed_simulation_result, conf
     assert rows == 1
 
 
-def test_simulation(executed_simulation_result, config):
+def test_simulation_to_pandas_no_config_columns(result, config):
+    """Check that result coverts with no config column if columns is an empty list"""
+    df = save_simulation_result_to_pandas(result, config, config_columns=[])
+    shape = df.shape
+    assert len(shape) == 2
+    rows, cols = shape
+    assert cols == NUM_ATTRIBUTES_IN_RESULT
+    assert rows == 1
+
+
+def test_simulation(result, config):
+    """Result converts to data frame with specified columns"""
     config_columns = [
         "consignment/parameter_based/boxes/min",
         "consignment/parameter_based/boxes/max",
@@ -59,10 +74,7 @@ def test_simulation(executed_simulation_result, config):
         "avg_boxes_opened_detection",
     ]
     df = save_simulation_result_to_pandas(
-        executed_simulation_result,
-        config,
-        config_columns=config_columns,
-        result_columns=result_columns,
+        result, config, config_columns=config_columns, result_columns=result_columns
     )
     shape = df.shape
     assert len(shape) == 2
@@ -72,6 +84,7 @@ def test_simulation(executed_simulation_result, config):
 
 
 def test_scenarios(datadir):
+    """Scenario results convert to data frame with specified columns"""
     basic_config = load_configuration(datadir / "config.yml")
     scenario_table = load_scenario_table(datadir / "scenarios_config.csv")
     results = run_scenarios(

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -1,9 +1,77 @@
+import pytest
+
 from popsborder.inputs import load_configuration, load_scenario_table
-from popsborder.outputs import save_scenario_result_to_pandas
-from popsborder.scenarios import run_scenarios
+from popsborder.outputs import (
+    save_scenario_result_to_pandas,
+    save_simulation_result_to_pandas,
+)
+from popsborder.scenarios import run_scenarios, run_simulation
 
 
-def test_scenarios(datadir, tmp_path):
+NUM_ITEMS_IN_CONFIG = 33
+NUM_ATTRIBUTES_IN_RESULT = 25
+
+
+@pytest.fixture
+def config(datadir):
+    return load_configuration(datadir / "config.yml")
+
+
+@pytest.fixture
+def executed_simulation_result(config):
+    result = run_simulation(
+        config=config, seed=42, num_simulations=2, num_consignments=10
+    )
+    return result
+
+
+def test_simulation_to_pandas_default_columns(executed_simulation_result, config):
+    df = save_simulation_result_to_pandas(executed_simulation_result, config)
+    print(df)
+    shape = df.shape
+    assert len(shape) == 2
+    rows, cols = shape
+    assert cols == NUM_ITEMS_IN_CONFIG + NUM_ATTRIBUTES_IN_RESULT
+    assert rows == 1
+
+
+def test_simulation_to_pandas_no_config_columns(executed_simulation_result, config):
+    df = save_simulation_result_to_pandas(
+        executed_simulation_result, config, config_columns=[]
+    )
+    shape = df.shape
+    assert len(shape) == 2
+    rows, cols = shape
+    assert cols == NUM_ATTRIBUTES_IN_RESULT
+    assert rows == 1
+
+
+def test_simulation(executed_simulation_result, config):
+    config_columns = [
+        "consignment/parameter_based/boxes/min",
+        "consignment/parameter_based/boxes/max",
+        "consignment/items_per_box/default",
+        "contamination/contamination_rate/parameters",
+    ]
+    result_columns = [
+        "missing",
+        "avg_boxes_opened_completion",
+        "avg_boxes_opened_detection",
+    ]
+    df = save_simulation_result_to_pandas(
+        executed_simulation_result,
+        config,
+        config_columns=config_columns,
+        result_columns=result_columns,
+    )
+    shape = df.shape
+    assert len(shape) == 2
+    rows, cols = shape
+    assert cols == len(config_columns) + len(result_columns)
+    assert rows == 1
+
+
+def test_scenarios(datadir):
     basic_config = load_configuration(datadir / "config.yml")
     scenario_table = load_scenario_table(datadir / "scenarios_config.csv")
     results = run_scenarios(


### PR DESCRIPTION
* Add conversion from one result to pandas data frame.
* By default, convert all config items and all result attributes to columns and values in a new data frame.
