### PR TITLE
Add main page for docs, fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you are not familiar with Binder, see
 
 Documentation is included in the [docs](docs/) directory.
 [command line interface](docs/cli.md)
-and [shipment configuration](docs/shipments.md)
+and [Consignment configuration](docs/consignments.md)
 pages are good ones to start with.
 
 ## Install

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# PoPS Border Documentation
+
+Start here: [Consignment configuration](consignments.md)
+
+To try it out use: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncsu-landscape-dynamics/popsborder/main?urlpath=lab/tree/examples/notebooks/basic_with_command_line.ipynb)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,4 +2,4 @@
 
 Start here: [Consignment configuration](consignments.md)
 
-To try it out use: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncsu-landscape-dynamics/popsborder/main?urlpath=lab/tree/examples/notebooks/basic_with_command_line.ipynb)
+To try it out, use: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncsu-landscape-dynamics/popsborder/main?urlpath=lab/tree/examples/notebooks/basic_with_command_line.ipynb)


### PR DESCRIPTION
- Add a readme file to the docs directory so that there is a page with text displayed, not just files.
- Fix link to shipments/consignments from the main readme to the docs.
