### PR TITLE
Replace remaining shipment in doc, fix typos

### DIFF
--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -22,14 +22,14 @@ propagule pressure for quarantine-significant pest species.
 
 ## what are the trade offs between effort and effectiveness for various inspection protocols?
 
-For example, is the inspection success rate higher when we isnpect fewer
+For example, is the inspection success rate higher when we inspect fewer
 consignments using hypergeometric random sampling, or when we inspect
 all consignments using convenience sampling?
 
 ## How sensitive are the inspections to level of contamination?
 
 Given a specific inspection protocol, what level of contamination
-needs to be present in the consigments for us to detect it? Additionally,
+needs to be present in the consignments for us to detect it? Additionally,
 how much pest needs to be present to raise alarms?
 
 In the following example, we inspect two boxes of each consignment,
@@ -52,7 +52,7 @@ different contamination rates and compare slippage rates.
 
 Using a given inspection protocol, would we successfully intercept
 a newly emerging pest? In this case, we would modify the parameters
-that control how contamiantion in consignments from certain origin
+that control how contamination in consignments from certain origin
 countries are added based on another model projecting an emerging pest.
 
 ## Generate synthetic F280 records

--- a/popsborder/consignments.py
+++ b/popsborder/consignments.py
@@ -142,7 +142,7 @@ class ParameterConsignmentGenerator:
     """Generate a consignments based on configuration parameters"""
 
     def __init__(self, parameters, items_per_box, start_date):
-        """Set parameters for shipement generation
+        """Set parameters for consignment generation
 
         :param parameters: Consignment parameters
         :param ports: List of ports to choose from

--- a/popsborder/outputs.py
+++ b/popsborder/outputs.py
@@ -250,7 +250,7 @@ class Form280(object):
         :param consignment: Consignment which was tested
         :param ok: True if the consignment was tested negative (no pest present)
         :param must_inspect: True if the consignment was selected for inspection
-        :param apllied_program: Identifier of the program applied or None
+        :param applied_program: Identifier of the program applied or None
         """
         disposition_code = self.disposition(ok, must_inspect, applied_program)
         if self.file:
@@ -286,7 +286,7 @@ class SuccessRates(object):
 
         :param checked_ok: True if no contaminant was found in consignment
         :param actually_ok: True if the consignment actually does not have contamination
-        :param shipmemt: The shipment itself (for reporting purposes)
+        :param consignment: The shipment itself (for reporting purposes)
         """
         if checked_ok and actually_ok:
             self.true_negative += 1


### PR DESCRIPTION
- Replace remaining shipment by consignment in Python doc.
- Fix typos in doc.
