### PR TITLE
Support contamination distribution parameters as mapping

### DIFF
--- a/docs/contamination.md
+++ b/docs/contamination.md
@@ -37,6 +37,26 @@ contamination:
       - 60
 ```
 
+The distribution parameters can also be specified as a mapping (dictionary) with
+`a` being the first parameter and `b` the second:
+
+```yaml
+contamination:
+  contamination_rate:
+    distribution: beta
+    parameters:
+      a: 4
+      b: 60
+```
+
+In tabular configuration, the above looks like:
+
+| Parameter key                                 | Value |
+| --------------------------------------------- | ----- |
+| contamination/contamination_rate/distribution | beta  |
+| contamination/contamination_rate/parameters/a | 4     |
+| contamination/contamination_rate/parameters/b | 60    |
+
 The possible values for `distribution` include `beta` and `fixed_value`.
 
 If `distribution` = `beta`, a beta probability distribution of contamination rates

--- a/tests/test_contamination.py
+++ b/tests/test_contamination.py
@@ -5,7 +5,10 @@ import datetime
 import pytest
 
 from popsborder.consignments import Consignment
-from popsborder.contamination import get_contamination_config_for_consignment
+from popsborder.contamination import (
+    get_contamination_config_for_consignment,
+    get_contamination_rate,
+)
 from popsborder.inputs import load_configuration_yaml_from_text
 
 CONFIG = """\
@@ -210,3 +213,31 @@ def test_contamination_config_for_consignment_with_default():
         main_config["contamination"], consignment
     )
     assert config == {"contamination_unit": "box", "arrangement": "random"}
+
+
+CONTAMINATION_RATE_LIST = """\
+contamination:
+  contamination_rate:
+    distribution: beta
+    parameters:
+      - 4
+      - 60
+"""
+
+CONTAMINATION_RATE_DICT = """\
+contamination:
+  contamination_rate:
+    distribution: beta
+    parameters:
+      a: 4
+      b: 60
+"""
+
+
+@pytest.mark.parametrize("config", CONTAMINATION_RATE_LIST, CONTAMINATION_RATE_DICT)
+def test_contamination_rate_dict_config(config):
+    """Contamination rate function accepts list and mapping as params"""
+    config = load_configuration_yaml_from_text(config)
+    rate = get_contamination_rate(config["contamination"]["contamination_rate"])
+    assert rate >= 0
+    assert rate <= 1

--- a/tests/test_contamination.py
+++ b/tests/test_contamination.py
@@ -234,7 +234,7 @@ contamination:
 """
 
 
-@pytest.mark.parametrize("config", CONTAMINATION_RATE_LIST, CONTAMINATION_RATE_DICT)
+@pytest.mark.parametrize("config", [CONTAMINATION_RATE_LIST, CONTAMINATION_RATE_DICT])
 def test_contamination_rate_dict_config(config):
     """Contamination rate function accepts list and mapping as params"""
     config = load_configuration_yaml_from_text(config)


### PR DESCRIPTION
The two parameters for the Beta distribution for contaminants can now be specified by keys a and b instead of a list of parameters. This makes the syntax in tabular configuration formats easier (only keys, not indices or two values instead of one JSON list as value).
