### PR TITLE
Include linked files in configuration

### DIFF
--- a/docs/run.md
+++ b/docs/run.md
@@ -4,6 +4,8 @@ The two basic ways to run the simulation are a Python package and command line
 interface. Both interfaces take simulation parameters as a configuration file
 and several other user inputs as function arguments or command line arguments.
 
+## Configuration
+
 The configuration file contains all parameters needed for a single simulation
 run. The package documentation explains the configuration parameters in detail.
 The configuration format is key-value pairs structured hierarchically. The
@@ -37,6 +39,8 @@ The path to the base configuration file must be provided as a function or
 command line argument, possibly with other values for the spreadsheet formats,
 along with the number consignments and stochastic runs to simulate.
 
+## Running
+
 You can use the package from the command line (using the command line interface
 of the Python package) or directly from Python (within an IDE or Jupyter
 Notebook). While calling the functions in Python is flexible and advantageous
@@ -46,6 +50,8 @@ of the consignment inspections or the simulation itself. Python API is
 documented in docstrings (available in code or through Python help function).
 For running simulation in the command line, see a dedicated [CLI page](cli.md)
 in this documentation.
+
+## Scenarios
 
 For running many scenarios at once, a Python function,
 `popsborder.scenarios.run_scenarios` is provided which in addition to the base
@@ -59,6 +65,100 @@ formats described above. The values can use JSON syntax to specify lists or
 nested values (e.g., `[1, 2]`). The values returned from the function can be
 used for further processing or visualization in Python. Alternatively, these can
 be saved to a file using Python and processed elsewhere.
+
+## Including other configuration files
+
+For complex scenarios where a significant portion of the configuration changes,
+it is advantageous to use a separate configuration files for the variable portion
+of the configuration. This is especially useful when the (tree) structure of the
+configuration changes and thus would be difficult to express by values in a scenario
+configuration under a single key `key/subkey/subsubkey` (you can include a complex JSON
+structure as the value, but it would be hard to read and maintain).
+
+For example, when `consignments` under `contamination` significantly differ for each scenario,
+i.e., more than just few values are changed, the whole list of contamination settings
+for consignments can be placed in a separate file and this file can be included. In this case,
+the main configuration file contains:
+
+```yaml
+contamination:
+  consignments:
+    include_file:
+      file_name: consignments_list.yml
+```
+
+The included `consignments_list.yml` file with the list of contamination settings
+for consignments can look like this:
+
+```yaml
+- commodity: Liatris
+  origin: Netherlands
+  contamination:
+    arrangement: random_box
+- commodity: Gerbera
+  origin: Netherlands
+  contamination:
+    arrangement: random
+- commodity: Hyacinthus
+  origin: Israel
+  contamination:
+    arrangement: random
+```
+
+For scenario configuration which is in tabular form with column headers as keys,
+the file inclusion for three scenarios would look like this:
+
+| name       | contamination/consignments/include_file/file_name |
+| ---------- | ------------------------------------------------- |
+| Scenario A | consignments_list_scenario_a.yml                  |
+| Scenario B | consignments_list_scenario_b.yml                  |
+| Scenario C | consignments_list_scenario_c.yml                  |
+
+The included file can be in the same formats as the main configuration file,
+i.e., hierarchical (in YAML or JSON) or tabular (in XLSX, ODS, CSV).
+For spreadsheet formats (XLSX, ODS) additional values should be provided for
+`sheet`, `key_column`, and `value_column` in the same way as this is done
+for the main configuration. Each scenario can have different combination of
+`sheet`, `key_column`, and `value_column` used, so for example, the `file_name`,
+`sheet`, and `key_column` can be fixed, but each scenario can have different
+`value_column`. In this example, assuming the other settings is in the
+base configuration file, the `include_file` for each scenario can look
+like this:
+
+| name       | contamination/consignments/include_file/value_column |
+| ---------- | ---------------------------------------------------- |
+| Scenario A | A                                                    |
+| Scenario B | B                                                    |
+| Scenario C | C                                                    |
+
+Additionally, for cases when the file contains a list of mappings (dictionaries)
+as in the above example, the file can be in tabular form with keys being
+column names similarly to the scenario table. In this case, value
+`list` needs to be specified for an additional `file_format` key.
+This value can be then specified in the base configuration (while the
+scenario configuration specifies only the file name):
+
+```yaml
+contamination:
+  consignments:
+    include_file:
+      file_name: consignments_list.csv
+      file_format: list
+```
+
+The included `consignments_list.csv` file with the list of contamination settings
+for consignments organized as a list (`file_format: list`) can look like this:
+
+| commodity  | origin      | contamination/arrangement |
+| ---------- | ----------- | ------------------------- |
+| Liatris    | Netherlands | random_box                |
+| Gerbera    | Netherlands | random                    |
+| Hyacinthus | Israel      | random                    |
+
+When the configuration is read, this table is translated to a list under
+`contamination/consignments`.
+
+## Examples
 
 Example scripts and (Jupyter) notebooks are included in the code repository. The
 notebooks are extremely useful for visualization of the simulation outcomes. You

--- a/docs/run.md
+++ b/docs/run.md
@@ -87,6 +87,12 @@ contamination:
       file_name: consignments_list.yml
 ```
 
+The `include_file` item is the only item under the `consignments` item
+and what is in the included file will be placed as the value of the `consignments` item
+replacing the `include_file` item. The file being included can contain any
+other items like mapping (dictionaries) or lists. These items will be used as is
+as the new `consignments` value.
+
 The included `consignments_list.yml` file with the list of contamination settings
 for consignments can look like this:
 

--- a/popsborder/inputs.py
+++ b/popsborder/inputs.py
@@ -198,9 +198,7 @@ def include_files(d: dict, base_file_name=None):
                 nested_value_column = value.get("value_column")
                 file_format = value.get("file_format")
                 if file_format == "list":
-                    values = load_scenario_table(
-                        nested_file,
-                    )
+                    values = load_scenario_table(nested_file)
                     new_value = []
                     for item in values:
                         new_value.append(record_to_nested_dictionary(item))

--- a/popsborder/inputs.py
+++ b/popsborder/inputs.py
@@ -196,7 +196,21 @@ def include_files(d: dict, base_file_name=None):
                 nested_sheet = value.get("sheet")
                 nested_key_column = value.get("key_column")
                 nested_value_column = value.get("value_column")
-                new_value = load_configuration_2(nested_file, sheet=nested_sheet, key_column=nested_key_column, value_column=nested_value_column)
+                file_format = value.get("file_format")
+                if file_format == "list":
+                    values = load_scenario_table(
+                        nested_file,
+                    )
+                    new_value = []
+                    for item in values:
+                        new_value.append(record_to_nested_dictionary(item))
+                else:
+                    new_value = load_configuration_2(
+                        nested_file,
+                        sheet=nested_sheet,
+                        key_column=nested_key_column,
+                        value_column=nested_value_column,
+                    )
                 d[key] = new_value
             else:
                 include_files(value, base_file_name)
@@ -217,7 +231,9 @@ def load_configuration(filename, sheet=None, key_column=None, value_column=None)
     The same information can be passed directly as function parameters.
     If both are provided, function parameters take precedence.
     """
-    config = load_configuration_2(filename, sheet=sheet, key_column=key_column, value_column=value_column)
+    config = load_configuration_2(
+        filename, sheet=sheet, key_column=key_column, value_column=value_column
+    )
     include_files(config, base_file_name=filename)
     return config
 

--- a/popsborder/simulation.py
+++ b/popsborder/simulation.py
@@ -34,7 +34,6 @@ from .inspections import (
     inspect,
     is_consignment_contaminated,
 )
-from .skipping import get_inspection_needed_function
 from .outputs import (
     Form280,
     MuteReporter,
@@ -42,6 +41,7 @@ from .outputs import (
     SuccessRates,
     pretty_consignment,
 )
+from .skipping import get_inspection_needed_function
 
 
 def random_seed(seed):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -103,7 +103,6 @@ def test_dict_config_to_table(datadir):
 
 def test_include_files(datadir):
     config = load_configuration(datadir / "small_config_with_includes.yml")
-    print(config)
     consignments = config["contamination"]["consignments"]
     assert isinstance(consignments, list)
     assert len(consignments) == 8
@@ -111,7 +110,6 @@ def test_include_files(datadir):
 
 def test_include_files_list(datadir):
     config = load_configuration(datadir / "small_config_with_list_includes.yml")
-    print(config)
     consignments = config["contamination"]["consignments"]
     assert isinstance(consignments, list)
     assert len(consignments) == 8

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,7 @@ def test_dict_config_to_table(datadir):
 
 
 def test_include_files(datadir):
+    """Included YAML file with a list loads"""
     config = load_configuration(datadir / "small_config_with_includes.yml")
     consignments = config["contamination"]["consignments"]
     assert isinstance(consignments, list)
@@ -109,16 +110,17 @@ def test_include_files(datadir):
 
 
 def test_include_files_list(datadir):
+    """Included CSV file formatted as a list of items loads"""
     config = load_configuration(datadir / "small_config_with_list_includes.yml")
     consignments = config["contamination"]["consignments"]
     assert isinstance(consignments, list)
-    assert len(consignments) == 8
+    assert len(consignments) == 7
     assert consignments[0] == {
         "commodity": "Liatris",
         "origin": "Netherlands",
         "contamination": {"arrangement": "random_box"},
     }
-    assert consignments[7] == {
+    assert consignments[-1] == {
         "commodity": "Sedum",
         "origin": "Colombia",
         "contamination": {"arrangement": "random"},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,3 +99,11 @@ def test_dict_config_to_table(datadir):
     print_table_config(table)
     config_table = load_configuration(table)
     assert config_table == config_yml
+
+
+def test_include_files(datadir):
+    config = load_configuration(datadir / "small_config_with_includes.yml")
+    print(config)
+    consignments = config["contamination"]["consignments"]
+    assert isinstance(consignments, list)
+    assert len(consignments) == 8

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -107,3 +107,21 @@ def test_include_files(datadir):
     consignments = config["contamination"]["consignments"]
     assert isinstance(consignments, list)
     assert len(consignments) == 8
+
+
+def test_include_files_list(datadir):
+    config = load_configuration(datadir / "small_config_with_list_includes.yml")
+    print(config)
+    consignments = config["contamination"]["consignments"]
+    assert isinstance(consignments, list)
+    assert len(consignments) == 8
+    assert consignments[0] == {
+        "commodity": "Liatris",
+        "origin": "Netherlands",
+        "contamination": {"arrangement": "random_box"},
+    }
+    assert consignments[7] == {
+        "commodity": "Sedum",
+        "origin": "Colombia",
+        "contamination": {"arrangement": "random"},
+    }

--- a/tests/test_config/consignments_list.csv
+++ b/tests/test_config/consignments_list.csv
@@ -1,7 +1,6 @@
 commodity,origin,contamination/arrangement
 Liatris,Netherlands,random_box
 Tulipa,Netherlands,random_box
-Gerbera,Netherlands,random_box
 Gerbera,Netherlands,random
 Hyacinthus,Israel,random
 Rose,Netherlands,random

--- a/tests/test_config/consignments_list.csv
+++ b/tests/test_config/consignments_list.csv
@@ -1,0 +1,9 @@
+commodity,origin,contamination/arrangement
+Liatris,Netherlands,random_box
+Tulipa,Netherlands,random_box
+Gerbera,Netherlands,random_box
+Gerbera,Netherlands,random
+Hyacinthus,Israel,random
+Rose,Netherlands,random
+Rose,Mexico,random
+Sedum,Colombia,random

--- a/tests/test_config/consignments_list.yml
+++ b/tests/test_config/consignments_list.yml
@@ -1,0 +1,36 @@
+- commodity: Liatris
+  origin: Netherlands
+  contamination:
+    arrangement: random_box
+- commodity: Tulipa
+  origin: Netherlands
+  start_date: 2022-09-29
+  end_date: 2022-10-15
+  contamination:
+    arrangement: random_box
+    contamination_unit: box
+- commodity: Gerbera
+  origin: Netherlands
+  end_date: 2022-04-10
+  contamination:
+    arrangement: random_box
+- commodity: Gerbera
+  origin: Netherlands
+  start_date: 2022-08-20
+  contamination:
+    contamination_unit: item
+- commodity: Hyacinthus
+  origin: Israel
+- commodity: Rose
+  origin: Netherlands
+  use_contamination_defaults: false
+  contamination:
+    contamination_unit: box
+- commodity: Rose
+  origin: Mexico
+  use_contamination_defaults: true
+  contamination:
+    contamination_unit: box
+- commodity: Sedum
+  origin: Colombia
+  port: FL Miami Air CBP

--- a/tests/test_config/small_config_with_includes.yml
+++ b/tests/test_config/small_config_with_includes.yml
@@ -1,0 +1,28 @@
+consignment:
+  generation_method: parameter_based
+  parameter_based:
+    ports:
+      - NY JFK CBP
+      - FL Miami Air CBP
+      - HI Honolulu CBP
+contamination:
+  consignments:
+    include_file:
+      file_name: consignments_list.yml
+  contamination_unit: item
+  contamination_rate:
+    distribution: beta
+    value: 0.01
+    parameters:
+      - 0.0194628
+      - 2.7609372
+  arrangement: random
+inspection:
+  unit: boxes
+  within_box_proportion: 1
+  tolerance_level: 0.005
+  sample_strategy: hypergeometric
+  hypergeometric:
+    detection_level: 0.1
+    confidence_level: 0.95
+  selection_strategy: random

--- a/tests/test_config/small_config_with_list_includes.yml
+++ b/tests/test_config/small_config_with_list_includes.yml
@@ -1,0 +1,29 @@
+consignment:
+  generation_method: parameter_based
+  parameter_based:
+    ports:
+      - NY JFK CBP
+      - FL Miami Air CBP
+      - HI Honolulu CBP
+contamination:
+  consignments:
+    include_file:
+      file_name: consignments_list.csv
+      file_format: list
+  contamination_unit: item
+  contamination_rate:
+    distribution: beta
+    value: 0.01
+    parameters:
+      - 0.0194628
+      - 2.7609372
+  arrangement: random
+inspection:
+  unit: boxes
+  within_box_proportion: 1
+  tolerance_level: 0.005
+  sample_strategy: hypergeometric
+  hypergeometric:
+    detection_level: 0.1
+    confidence_level: 0.95
+  selection_strategy: random


### PR DESCRIPTION
When include_file is present as an only key in a mapping, the mapping (value of the parent key) is replaced by the content of the linked file.
