### PR TITLE
Add date property to Consignment

### DIFF
--- a/popsborder/consignments.py
+++ b/popsborder/consignments.py
@@ -110,7 +110,7 @@ class Consignment(collections.UserDict):
         self.items = items
         self.items_per_box = items_per_box
         self.num_boxes = num_boxes
-        self.date = date
+        self._date = date
         self.boxes = boxes
         self.origin = origin
         self.port = port
@@ -118,6 +118,14 @@ class Consignment(collections.UserDict):
 
     def __getattr__(self, name):
         return self.name
+
+    @property
+    def date(self):
+        """Date of consignment (arrival) as datetime.date object"""
+        # For datetime.datetime, returns just date, assumes datetime.date otherwise.
+        if hasattr(self._date, "date"):
+            return self._date.date()
+        return self._date
 
     @property
     def commodity(self):

--- a/tests/test_consignments.py
+++ b/tests/test_consignments.py
@@ -1,0 +1,38 @@
+"""Test consignments generation and objects"""
+
+import datetime
+
+import pytest
+
+from popsborder.consignments import Consignment
+
+
+def simple_consignment(flower="Tulipa", origin="Netherlands", date=None):
+    """Get consignment with some default values"""
+    return Consignment(
+        flower=flower,
+        num_items=0,
+        items=0,
+        items_per_box=0,
+        num_boxes=0,
+        date=date,
+        boxes=[],
+        pathway="airport",
+        port="FL Miami Air CBP",
+        origin=origin,
+    )
+
+
+@pytest.mark.parametrize(
+    "date",
+    [
+        datetime.date(2022, 9, 29),
+        datetime.date(2022, 10, 1),
+        datetime.datetime(2022, 10, 10),
+        datetime.datetime(2022, 10, 15),
+    ],
+)
+def test_consignment_date_comapares(date):
+    """Check that consignment date attribute compares with date objects"""
+    consignment = simple_consignment(date=date)
+    assert consignment.date > datetime.date(2022, 9, 28)


### PR DESCRIPTION
A date property of Consignment now ensures that consignment.date is always a date object regardless of how the consignment was created. Test fails before because you can't compare datetime.datetime and datetime.date. The issue arises with F280 data and flower of the day.
