### PR TITLE
Fix attribute access to arbitrary consignmenty properties

### DIFF
--- a/popsborder/consignments.py
+++ b/popsborder/consignments.py
@@ -59,8 +59,8 @@ class Box:
 class Consignment(collections.UserDict):
     """A consignment with all its properties and what it contains.
 
-    Access is through attributes (new style) or using a dictionary-like item access
-    (old style).
+    Access its properties (attributes) is through attribute syntax (new style) or
+    using a dictionary-like item access (old style).
     """
 
     # Inheriting from this library class is its intended use, so disable ancestors msg.
@@ -116,8 +116,15 @@ class Consignment(collections.UserDict):
         self.port = port
         self.pathway = pathway
 
+    def __hasattr__(self, name):
+        return name in self
+
     def __getattr__(self, name):
-        return self.name
+        if name not in self:
+            raise AttributeError(
+                f"'{self.__class__.__name__}' object has no attribute '{name}'"
+            )
+        return self[name]
 
     @property
     def date(self):

--- a/tests/test_consignments.py
+++ b/tests/test_consignments.py
@@ -23,6 +23,48 @@ def simple_consignment(flower="Tulipa", origin="Netherlands", date=None):
     )
 
 
+def test_consignment_attribute_access():
+    """Check that consignment supports attribute access"""
+    consignment = simple_consignment(origin="Mexico")
+    assert consignment.origin == "Mexico"
+
+
+def test_consignment_dict_access():
+    """Check that consignment supports dictionary-like (index) access"""
+    consignment = simple_consignment(origin="Mexico")
+    assert consignment["origin"] == "Mexico"
+
+
+def test_consignment_attribute_access_unknown():
+    """Check that consignment invalid attribute access raises exception"""
+    consignment = simple_consignment()
+    with pytest.raises(AttributeError) as error:
+        consignment.does_not_exist  # pylint: disable=pointless-statement
+    assert "does_not_exist" in str(error.value)
+
+
+def test_consignment_dict_access_unknown():
+    """Check that consignment invalid dictionary-like access raises exception"""
+    consignment = simple_consignment()
+    with pytest.raises(KeyError) as error:
+        consignment["does_not_exist"]  # pylint: disable=pointless-statement
+    assert "does_not_exist" in str(error.value)
+
+
+def test_consignment_has_attr():
+    """Check that consignment works with hasattr"""
+    consignment = simple_consignment()
+    assert hasattr(consignment, "origin")
+    assert not hasattr(consignment, "does_not_exist")
+
+
+def test_consignment_flower_commodity():
+    """Check that consignment supports both commodity and flower as names for access"""
+    consignment = simple_consignment(flower="Tulipa")
+    assert consignment.flower == "Tulipa"
+    assert consignment.commodity == "Tulipa"
+
+
 @pytest.mark.parametrize(
     "date",
     [


### PR DESCRIPTION
- An infinite recursion was accidentally introduced in #90.
- Invalid attribute access did not raise the correct exception.
- Query for attribute existence was not supported.

The issue arised when using consignment objects with pytest.mark.parametrize.
