### PR TITLE
Add config for number of consignments per day

### DIFF
--- a/docs/consignments.md
+++ b/docs/consignments.md
@@ -108,6 +108,10 @@ ports:
   - WA Blaine CBP
 ```
 
+The generator also adds a date to each consignment. Number of consignments
+generated per day, i.e., number of consignments after which a new day begins,
+is driven by `consignments_per_day` which defaults to 1.
+
 ## Create consignments to match an input file
 
 To use a file of inspection records, set the `generation_method` to `input_file`


### PR DESCRIPTION
Adds one new configuration value for the number of consignments generated per day. Implemented as a counter of consigments generated when then is used to advance the day. Previous implementation was increasing the day every 3rd consignment.
